### PR TITLE
fix: aria-label next and prev IconButtons

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -257,13 +257,13 @@ class Carousel extends Component
                 }
                 
                 <div className={`${buttonWrapperCssClassValue} ${classes.next}`}>
-                    <IconButton className={`${buttonCssClassValue} ${classes.next}`} onClick={this.next}>
+                    <IconButton className={`${buttonCssClassValue} ${classes.next}`} onClick={this.next} aria-label="Next">
                         <NavigateNextIcon/>
                     </IconButton>
                 </div>
 
                 <div className={`${buttonWrapperCssClassValue} ${classes.prev}`}>
-                    <IconButton className={`${buttonCssClassValue}  ${classes.prev}`} onClick={this.prev}>
+                    <IconButton className={`${buttonCssClassValue}  ${classes.prev}`} onClick={this.prev} aria-label="Previous">
                         <NavigateBeforeIcon/>
                     </IconButton>
                 </div>


### PR DESCRIPTION
Not a very critical change. Lighthouse a11y report didn't seem to like these two elements without tho.