### PR TITLE
Reset active index when children updated to be smaller than index

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -125,6 +125,13 @@ class Carousel extends Component
             if (nextProps.children.length !== prevState.childrenLength)
             {
                 newState = {childrenLength: nextProps.children.length, ...newState};
+
+                // If the current active index is bigger than the new children length, set it to be the last child (if strictIndexing)
+                const strictIndexing = nextProps.strictIndexing !== undefined ? nextProps.strictIndexing : true;
+                if (strictIndexing && prevState.active > nextProps.children.length - 1) {
+                    newState.active = nextProps.children.length - 1;
+                    newState.displayed = nextProps.children.length - 1;
+                }
             }
         }
         else {


### PR DESCRIPTION
This fixes the issue that when the children are dynamically updated to be smaller than the current index it displays nothing and has no active indicator dot (#27).

I've tested this locally and it seems to work well enough but I'm not familiar enough with the internal state of the component to know if something else needs to be done (maybe a check in `componentDidUpdate` to call `reset`?).

Hope this can be usable, but let me know if I need to change anything.