### PR TITLE
Switched material-ui imports to path imports

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
-import {Fade, Slide, IconButton} from '@material-ui/core';
+import Fade from '@material-ui/core/Fade';
+import Slide from '@material-ui/core/Slide';
+import IconButton from '@material-ui/core/IconButton';
 import { withStyles } from '@material-ui/core/styles';
 import autoBind from 'auto-bind';
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';


### PR DESCRIPTION
Hello, I really like this component and thanks for creating it! 

I noticed that after importing it in my bundle size increased by 215kb. In the [MUI docs](https://material-ui.com/guides/minimizing-bundle-size/#option-1) they recommend path imports instead of importing from the top level. Once I made this switch my bundle size only increased by like 20kb.