### PR TITLE
BugFix: Buttons are not hidden by default 

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -306,7 +306,7 @@ class Carousel extends Component
 
         const classes = this.props.classes;
         
-        const buttonVisibilityClassValue = `${navButtonsAlwaysVisible ? classes.buttonVisible : classes.buttonHidden}}`;
+        const buttonVisibilityClassValue = `${navButtonsAlwaysVisible ? classes.buttonVisible : classes.buttonHidden}`;
         const buttonCssClassValue = `${classes.button} ${buttonVisibilityClassValue} ${fullHeightHover ? classes.fullHeightHoverButton : ""} ${navButtonsProps.className}`;
         const buttonWrapperCssClassValue = `${classes.buttonWrapper} ${fullHeightHover ? classes.fullHeightHoverWrapper : ""} ${navButtonsWrapperProps.className}`;
 


### PR DESCRIPTION
Extra } closing bracket inside of a template literals affecting the default hidden state  for  next and back buttons