### PR TITLE
enhancement: carousel to stop on keyboard focus for accessibility

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -356,6 +356,8 @@ class Carousel extends Component
                 className={`${classes.root} ${className ? className : ""}`}
                 onMouseOver={() => {stopAutoPlayOnHover && this.stop()}}
                 onMouseOut={() => {stopAutoPlayOnHover && this.reset()}}
+                onFocus={()=>{stopAutoPlayOnHover && this.stop()}}
+                onBlur={()=>{stopAutoPlayOnHover && this.reset()}}
             >
                 {   
                     Array.isArray(children) ? 


### PR DESCRIPTION
Hi!

I came across [this enhancement issue](https://github.com/Learus/react-material-ui-carousel/issues/137), and I think this could be a potential fix so I'm raising a PR. With this fix, focus on any of the child (eg button, indicator, next/prev) in the carousel causes the carousel to stop, which is the expected behaviour as per WCAG (here's [w3's example](https://www.w3.org/WAI/tutorials/carousels/working-example/)).

Let me know what you think!

