### PR TITLE
[version 3] enhancement: carousel to stop on keyboard focus for accessibility

### DIFF
--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -154,6 +154,8 @@ export const Carousel = (props: CarouselProps) =>
             className={className}
             onMouseOver={() => { stopAutoPlayOnHover && setPaused(true) }}
             onMouseOut={() => { stopAutoPlayOnHover && setPaused(false) }}
+            onFocus={()=>{stopAutoPlayOnHover && setPaused(true)}}
+            onBlur={()=>{stopAutoPlayOnHover && setPaused(false)}}
         >
             <StyledItemWrapper style={{ height: height }}>
                 {


### PR DESCRIPTION
This PR concerns [this issue](https://github.com/Learus/react-material-ui-carousel/issues/137), and is being made for the latest release (version3) to ensure consistent behaviour with other versions