### PR TITLE
[version 2 mui] enhancement: carousel to stop on keyboard focus for accessibility

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -358,6 +358,8 @@ class Carousel extends Component
                     className={`${classes.root} ${className ? className : ""}`}
                     onMouseOver={() => {stopAutoPlayOnHover && this.stop()}}
                     onMouseOut={() => {stopAutoPlayOnHover && this.reset()}}
+                    onFocus={()=>{stopAutoPlayOnHover && this.stop()}}
+                    onBlur={()=>{stopAutoPlayOnHover&& this.reset()}}
                 >
                     {   
                         Array.isArray(children) ? 


### PR DESCRIPTION
This PR concerns [this issue](https://github.com/Learus/react-material-ui-carousel/issues/137), and is being made for the latest release (version3) to ensure consistent behaviour with other versions