### PR TITLE
fix item height detection

### DIFF
--- a/src/components/CarouselItem.tsx
+++ b/src/components/CarouselItem.tsx
@@ -65,7 +65,7 @@ export const CarouselItem = ({ animation, next, prev, swipe, state, index, maxIn
     }, [setHeight, state.active, index, divRef])
 
     // Set height on every child change
-    useEffect(() =>
+    useLayoutEffect(() =>
     {
         checkAndSetHeight();
             


### PR DESCRIPTION
Get the height of the item after the dom has been render

fix #189 